### PR TITLE
Add scope and containerRuntime on chart values

### DIFF
--- a/charts/vessl/templates/clusterrole-binding.yaml
+++ b/charts/vessl/templates/clusterrole-binding.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.agent.scope "cluster" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -18,3 +19,4 @@ subjects:
   - kind: ServiceAccount
     name: vessl
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/vessl/templates/clusterrole.yaml
+++ b/charts/vessl/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.agent.scope "cluster" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,3 +11,4 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["*"]
+{{- end }}

--- a/charts/vessl/templates/deployment.yaml
+++ b/charts/vessl/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
             - name: VESSL_KUBERNETES_INGRESS_ENDPOINT
               value: "{{ .Values.agent.ingressEndpoint }}"
             {{- end }}
+            - name: VESSL_AGENT_SCOPE
+              value: "{{ .Values.agent.scope }}"
+            - name: VESSL_CONTAINER_RUNTIME
+              value: "{{ .Values.agent.containerRuntime }}"
             - name: VESSL_PROVIDER_TYPE
               value: "{{ .Values.agent.providerType }}"
           volumeMounts:

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -8,6 +8,8 @@ agent:
   env: prod
   image: "quay.io/vessl-ai/cluster-agent:0.6.17"
   sentryDsn: https://0481c31171114c109ac911ac947f0518@o386227.ingest.sentry.io/5585090
+  scope: cluster # cluster, namespace
+  containerRuntime: containerd # containerd, docker
   ingressEndpoint: # To be deprecated
   nodeSelector: {}
   tolerations:


### PR DESCRIPTION
Scope와 Container Runtime을 chart value에 추가합니다.
- Scope
  - agent의 권한 범위가 cluster-wide인지 namespace-wide인지 결정합니다. default는 cluster입니다. 
  - agent의 Informer의 스캔 범위를 해당 scope를 보고 결정하며, 권한 범위가 namespace-wide인 경우 cluster의 타 organization 권한 허용을 거부할 예정입니다. (org별 워크로드 분리를 네임스페이스로 해야 하므로)
- ContainerRuntime
  - 기본 containerd 입니다.
  - 1.23 아래는 docker를 아직 쓰고 있고 OCI의 경우 CRI-O를 쓰고 있어 선택 가능하게 하였습니다.
  - 백엔드에 이 값을 올려주고, 백엔드는 이 값에 따라 fluentd 사이드카가 컨테이너 로그 파싱을 하는 로직을 바꿔서 워크로드를 스케줄링 할 것입니다.