### PR TITLE
Add agent.localStorageClassName

### DIFF
--- a/charts/vessl/templates/deployment.yaml
+++ b/charts/vessl/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
               value: "{{ .Values.agent.containerRuntime }}"
             - name: VESSL_PROVIDER_TYPE
               value: "{{ .Values.agent.providerType }}"
+            {{- if .Values.agent.localStorageClassName }}
+            - name: VESSL_LOCAL_STORAGE_CLASS_NAME
+              value: "{{ .Values.agent.localStorageClassName }}"
+            {{- end }}
           volumeMounts:
             - name: access-token
               readOnly: true

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -3,6 +3,7 @@ agent:
   clusterName:
   providerType: on-premise # on-premise, aws, gcp, oci, azure
   imagePullPolicy:
+  localStorageClassName:
   apiServer: https://api.vessl.ai
   logLevel: info
   env: prod


### PR DESCRIPTION
deepvisions 설치작업을 새 helm chart로 진행하는데, 구 helm chart에서 VESSL_LOCAL_STORAGE_CLASS_NAME이 사라져서 복구합니다.  
혹시 뭔가 의도가 있어서 뺀 것이라면 대체  사용법을 알려주시면 감사하겠습니다 