### PR TITLE
Add labels in kube_(...)_labels

### DIFF
--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -131,9 +131,17 @@ gfd:
 kube-state-metrics:
   enabled: true
   metricLabelsAllowlist:
+  # This option makes `kube_pod_labels`, `kube_deployment_labels`, etc. contain all labels
+  # (including those like `label_v1_k8s_vessl_ai_partition="xxxx"`) of the Kubernetes object.
+  # This is used when aggregating values by Kubernetes resources' `*_vessl_ai_*` labels
+  # to provide metrics and graphs.
+  # The list should be extended when a new kind of resource requires label-joining.
     - deployments=[*]
+    - jobs=[*]
     - nodes=[*]
     - pods=[*]
+    - replicasets=[*]
+    - statefulsets=[*]
   tolerations:
     - key: "node-role.kubernetes.io/master"
       operator: "Equal"

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -130,6 +130,10 @@ gfd:
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
 kube-state-metrics:
   enabled: true
+  metricLabelsAllowlist:
+    - deployments=[*]
+    - nodes=[*]
+    - pods=[*]
   tolerations:
     - key: "node-role.kubernetes.io/master"
       operator: "Equal"


### PR DESCRIPTION
# 변경 내용
* `kube-state-metrics`의 metricLabelsAllowList에 Deployment, Node, Pod을 추가합니다.

# 설명
내부적으로 label에 matcher를 걸어서 join하여 쓰는 경우가 있는데, 이를 위해서는 kube-state-metrics가 `kube_pod_labels`, `kube_deployment_labels` 등의 메트릭을 제공해야 합니다.

이 label들이 굉장히 비대해질 수 있어서 혹시 모를 cardinality issue가 있을 수 있습니다.
그래서 TODO가 있는데, pub/sub 중 어느 한 쪽만 수정하면 됩니다.

* kube-state-metrics가 꼭 필요한 label만 제공하도록 합니다. (이 PR의 `*` 부분을 아예 직접 다 나열하는 것입니다.)
  * 이게 regex 같은 걸 못 쓰고 plain-text match라서, 나열을 해야 합니다.
  https://github.com/kubernetes/kube-state-metrics/blob/a9bdda09b92ef7508aa46069b7e2043850107ccf/internal/store/utils.go#L176-L195
* Prometheus 설정에서 이 메트릭을 처리할 때, 꼭 필요한 label만 남기고 지웁니다. (metric label keep/drop)
  * 여기는 regex(RE2)를 쓸 수 있습니다.

dev에 머지했을 때 잘 되는 것 확인했습니다.