### PR TITLE
TANDS-188 Add deviceListStrategy

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.11-rc2
+version: 0.0.11
 appVersion: "0.6.19"
 dependencies:
 - name: node-feature-discovery

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -49,6 +49,7 @@ agent:
 # https://github.com/NVIDIA/k8s-device-plugin/tree/main/deployments/helm/nvidia-device-plugin
 nvidia-device-plugin:
   enabled: true
+  deviceListStrategy: volume-mounts
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -380,7 +380,7 @@ local-path-provisioner:
                 values: ["manager"]
 
 longhorn:
-  enabled: true
+  enabled: false
   # https://longhorn.io/docs/1.5.1/advanced-resources/deploy/customizing-default-settings/#using-helm
   defaultSettings:
     defaultReplicaCount: 1


### PR DESCRIPTION
### Summary

nvidia-device-plugin에서 deviceListStrategy이 빠져 container runtime이 제대로 동작하고 있지 않아 추가합니다. (cluster-resource에도 동일한 설정이 있음)

longhorn은 아직 정식 사용은 아니기 때문에 `enabled: false`로만 변경합니다.