### PR TITLE
[VSSL-6806] Allow TorchServe metrics

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.14
+version: 0.0.15
 appVersion: "0.6.20"
 dependencies:
 - name: node-feature-discovery

--- a/charts/vessl/templates/configmap.yaml
+++ b/charts/vessl/templates/configmap.yaml
@@ -193,7 +193,7 @@ data:
       metric_relabel_configs:
       - source_labels:
         - __name__
-        regex: (bentoml_(.+)|BENTOML_(.+)|nv_(.+)|)
+        regex: (bentoml_(.+)|BENTOML_(.+)|nv_(.+)|Requests[245]XX|ts_inference_(.+))
         action: keep
 
     - job_name: vessl-node-exporter-servicemonitor


### PR DESCRIPTION
# 변경 내용
TorchServe에서 제공하는 메트릭

* `Requests2XX`, `Requests4XX`, `Requests5XX`
* `ts_inference_latency_microseconds`
* `ts_inference_requests_total`

을 제공합니다.