### PR TITLE
Set storage class parameters: defaultReplica and dataLocality

### DIFF
--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -383,6 +383,9 @@ local-path-provisioner:
 longhorn:
   enabled: true
   # https://longhorn.io/docs/1.5.1/advanced-resources/deploy/customizing-default-settings/#using-helm
+  persistence:
+    defaultClassReplicaCount: 1
+    defaultDataLocality: strict-local
   defaultSettings:
     defaultReplicaCount: 1
     defaultDataLocality: strict-local


### PR DESCRIPTION
기존 default value들은 longhorn UI를 통해 생성할 때의 기본값이었고, StorageClass에 두 파라미터가 박히지 않아 실제로 적용되지 않고 있었습니다. StorageClass에 적용되도록 기본값을 추가합니다.