### PR TITLE
[VSSL-7634] Create clusterrole when agent scope is namespace

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.25-rc3
+version: 0.0.25
 appVersion: "0.6.20"
 dependencies:
 - name: node-feature-discovery

--- a/charts/vessl/templates/clusterrole-binding.yaml
+++ b/charts/vessl/templates/clusterrole-binding.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.agent.scope "cluster" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -19,4 +18,3 @@ subjects:
   - kind: ServiceAccount
     name: vessl
     namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/charts/vessl/templates/clusterrole.yaml
+++ b/charts/vessl/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.agent.scope "cluster" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,6 +8,9 @@ metadata:
   {{- end }}
 rules:
   - apiGroups: ["*"]
+    {{- if eq .Values.agent.scope "cluster" }}
     resources: ["*"]
+    {{- else }}
+    resources: ["nodes"]
+    {{- end }}
     verbs: ["*"]
-{{- end }}


### PR DESCRIPTION
### Summary

scope가 namespace인 경우 node 정보를 못가져와 정상적으로 동작하지 않습니다.
원인으론 clusterrole을 생성하고 있지 않기 때문이며, namespace에서도 clusterrole을 생성하도록 변경합니다.
