### PR TITLE
0.0.27

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.26
+version: 0.0.27
 appVersion: "0.6.20"
 dependencies:
 - name: node-feature-discovery


### PR DESCRIPTION
변경사항이 이미 main에 들어갔습니다(https://github.com/vessl-ai/helm-charts/commit/93aa55e22ab721d236d252770688f31786377ee3)

k0s 1.29 설치시 control plane label이 `node-role.kubernetes.io/control-plane=true` 가 붙어서 대응하기 위해 Exists로 수정합니다.