### PR TITLE
Remove metrics relabel config on model service related configs

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.32
+version: 0.0.33
 appVersion: "0.6.21"
 dependencies:
 - name: node-feature-discovery

--- a/charts/vessl/templates/configmap.yaml
+++ b/charts/vessl/templates/configmap.yaml
@@ -167,6 +167,14 @@ data:
       kubernetes_sd_configs:
       - role: endpoints
       metrics_path: /metrics
+      metric_relabel_configs:
+      - source_labels:
+          - __name__
+        target_label: __name__
+        replacement: vessl_${1}
+        regex: (.*)
+        separator: ;
+        action: replace
       relabel_configs:
       - source_labels:
         - job

--- a/charts/vessl/templates/configmap.yaml
+++ b/charts/vessl/templates/configmap.yaml
@@ -190,11 +190,6 @@ data:
         - __tmp_hash
         regex: 0
         action: keep
-      metric_relabel_configs:
-      - source_labels:
-        - __name__
-        regex: (bentoml_(.+)|BENTOML_(.+)|nv_(.+)|Requests[245]XX|ts_inference_(.+)|vllm:(.+)|vessl:(.+))
-        action: keep
 
     - job_name: vessl-node-exporter-servicemonitor
       honor_labels: true


### PR DESCRIPTION
해당 메트릭만 존재한다는 가정이 깨져서 지웁니다.
managed aws oregon에서 지워서 임의로 테스트했습니다. 머지시 gke도 반영이 필요합니다.