### PR TITLE
Support USE_VIRTUAL_SERVER Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ helm repo add gpu-feature-discovery https://nvidia.github.io/gpu-feature-discove
 helm repo add prometheus https://prometheus-community.github.io/helm-charts
 helm repo add dcgm-exporter https://nvidia.github.io/dcgm-exporter/helm-charts
 helm repo add nvidia-k8s-device-plugin https://nvidia.github.io/k8s-device-plugin
+helm repo add nginx-ingress https://helm.nginx.com/stable
 helm repo update
 ```
 

--- a/charts/vessl/templates/deployment.yaml
+++ b/charts/vessl/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
               value: "{{ .Values.agent.containerRuntime }}"
             - name: VESSL_PROVIDER_TYPE
               value: "{{ .Values.agent.providerType }}"
+            - name: USE_VIRTUAL_SERVER
+              value: "{{ index .Values "nginx-ingress" "enabled" }}"
           volumeMounts:
             - name: access-token
               readOnly: true

--- a/charts/vessl/templates/deployment.yaml
+++ b/charts/vessl/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
               value: "{{ .Values.agent.containerRuntime }}"
             - name: VESSL_PROVIDER_TYPE
               value: "{{ .Values.agent.providerType }}"
-            - name: USE_VIRTUAL_SERVER
+            - name: VESSL_USE_VIRTUAL_SERVER
               value: "{{ index .Values "nginx-ingress" "enabled" }}"
           volumeMounts:
             - name: access-token

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -6,7 +6,7 @@ agent:
   apiServer: https://api.vessl.ai
   logLevel: info
   env: prod
-  image: "quay.io/vessl-ai/cluster-agent:0.6.24"
+  image: "quay.io/vessl-ai/cluster-agent:0.6.28"
   sentryDsn: https://0481c31171114c109ac911ac947f0518@o386227.ingest.sentry.io/5585090
   scope: cluster # cluster, namespace
   containerRuntime: containerd # containerd, docker, crio

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  accessToken: # required
+  accessToken: sd # required
   clusterName:
   providerType: on-premise # on-premise, aws, gcp, oci, azure
   imagePullPolicy:

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  accessToken: sd # required
+  accessToken: # required
   clusterName:
   providerType: on-premise # on-premise, aws, gcp, oci, azure
   imagePullPolicy:


### PR DESCRIPTION
chart에서 nginx-ingress(vessl-nginx)를 설치하면 agent 내 USE_VIRTUAL_SERVER가 활성화 됩니다.