### PR TITLE
Upgrade subchart versions

### DIFF
--- a/charts/vessl/Chart.lock
+++ b/charts/vessl/Chart.lock
@@ -1,22 +1,19 @@
 dependencies:
 - name: node-feature-discovery
   repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-  version: 0.15.4
-- name: gpu-feature-discovery
-  repository: https://nvidia.github.io/gpu-feature-discovery
-  version: 0.8.2
+  version: 0.17.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.19.0
+  version: 5.30.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.33.0
+  version: 4.44.0
 - name: dcgm-exporter
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
-  version: 3.4.1
+  version: 4.0.3
 - name: nvidia-device-plugin
   repository: https://nvidia.github.io/k8s-device-plugin
-  version: 0.15.0
+  version: 0.17.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 23.2.0
@@ -41,5 +38,5 @@ dependencies:
 - name: nginx-ingress
   repository: https://helm.nginx.com/stable
   version: 2.0.0
-digest: sha256:853e20678d7d0b7d1e9ad9607465cdfd29f291c4bf094fa41b20c241fe906522
-generated: "2025-02-07T18:36:34.961101+09:00"
+digest: sha256:9554e8dca973ef5409d4c6464e2ccebf0f33bae34a2e39c531653eed924fda8a
+generated: "2025-02-21T01:44:20.299572+09:00"

--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,34 +1,29 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.48
+version: 0.0.49
 appVersion: "0.6.24"
 dependencies:
 - name: node-feature-discovery
-  version: "0.15.4"
+  version: "0.17.1"
   alias: nfd
   condition: nfd.enabled
   repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-- name: gpu-feature-discovery
-  version: "0.8.2"
-  alias: gfd
-  condition: gfd.enabled
-  repository: https://nvidia.github.io/gpu-feature-discovery
 - name: kube-state-metrics
-  version: "5.19.0"
+  version: "5.30.0"
   condition: kube-state-metrics.enabled
   repository: https://prometheus-community.github.io/helm-charts
 - name: prometheus-node-exporter
   alias: node-exporter
-  version: "4.33.0"
+  version: "4.44.0"
   condition: node-exporter.enabled
   repository: https://prometheus-community.github.io/helm-charts
 - name: dcgm-exporter
-  version: "3.4.1"
+  version: "4.0.3"
   condition: dcgm-exporter.enabled
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
 - name: nvidia-device-plugin
-  version: "0.15.0"
+  version: "0.17.0"
   condition: nvidia-device-plugin.enabled
   repository: https://nvidia.github.io/k8s-device-plugin
 - name: prometheus

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -82,6 +82,8 @@ nvidia-device-plugin:
                 operator: In
                 values:
                   - "true"
+  gfd:
+    enabled: true
 
 # https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery
 nfd:
@@ -127,15 +129,6 @@ nfd:
             - "0302"
           deviceLabelFields:
             - "vendor"
-
-# https://github.com/NVIDIA/gpu-feature-discovery/tree/main/deployments/helm/gpu-feature-discovery
-gfd:
-  enabled: true
-  tolerations:
-    - operator: "Exists"
-      effect: "NoSchedule"
-  nfd:
-    enabled: false
 
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
 kube-state-metrics:


### PR DESCRIPTION
한화생명 오픈소스 보안 진단 대응으로 차트들 버전을 모두 최신으로 올립니다.

gfd가 nvidia/k8s-device-plugin 차트로 합병되어서 반영했습니다.
(https://github.com/NVIDIA/k8s-device-plugin/blob/main/deployments/helm/nvidia-device-plugin/values.yaml)