### PR TITLE
Add AllowInsecureTLS, use agent 0.6.30-rc1

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.54
-appVersion: "0.6.29"
+version: 0.0.55
+appVersion: "0.6.30-rc1"
 dependencies:
 - name: node-feature-discovery
   version: "0.17.2"

--- a/charts/vessl/templates/deployment.yaml
+++ b/charts/vessl/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: "{{ .Values.agent.providerType }}"
             - name: VESSL_USE_VIRTUAL_SERVER
               value: "{{ index .Values "nginx-ingress" "enabled" }}"
+            - name: VESSL_ALLOW_INSECURE_TLS
+              value: "{{ .Values.agent.allowInsecureTLS }}"
           volumeMounts:
             - name: access-token
               readOnly: true

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -6,11 +6,12 @@ agent:
   apiServer: https://api.vessl.ai
   logLevel: info
   env: prod
-  image: "quay.io/vessl-ai/cluster-agent:0.6.29"
+  image: "quay.io/vessl-ai/cluster-agent:0.6.30-rc1"
   sentryDsn: https://0481c31171114c109ac911ac947f0518@o386227.ingest.sentry.io/5585090
   scope: cluster # cluster, namespace
   containerRuntime: containerd # containerd, docker, crio
   clusterServiceType: Ingress # Ingress, LoadBalancer, NodePort
+  allowInsecureTLS: false
   region: "" # on-premise, <CLOUD_REGION>
   gpuPools: [] # this property is only used for the oci providerType
 #    - name: "a10-test"


### PR DESCRIPTION
In air-gapped environments where the platform operates over HTTPS, there are cases where TLS certificates may not be properly signed or validated—particularly in testing environments.

To ensure agents can still be initialized under such conditions, we are introducing the VESSL_ALLOW_INSECURE_TLS environment variable. This allows greater flexibility during development and testing, even when properly signed certificates are not available.

See also: https://github.com/vessl-ai/cluster-agent/pull/85