### PR TITLE
[VSSL-12753] Loop device mount concurrency error

### DIFF
--- a/charts/vessl/charts/lpp-advanced-config/files/quota_setup.sh
+++ b/charts/vessl/charts/lpp-advanced-config/files/quota_setup.sh
@@ -45,7 +45,7 @@ _cleanup() {
 }
 
 # Set up trap to call cleanup on any error
-trap _cleanup ERR
+trap _cleanup EXIT
 
 _create_dir() {
     /bin/echo -e "\033[1;32mCreating directory\033[0m: ${VOL_DIR}"
@@ -112,6 +112,6 @@ _check_disk_space
 _setup_quota
 
 # Remove trap since we succeeded
-trap - ERR
+trap - EXIT
 
 /bin/echo -e "\033[1;32mSetup complete!\033[0m"

--- a/charts/vessl/charts/lpp-advanced-config/files/quota_teardown.sh
+++ b/charts/vessl/charts/lpp-advanced-config/files/quota_teardown.sh
@@ -6,9 +6,12 @@ IMAGE_FILE="${VOL_DIR_PARENT}/${PROJ_NAME}.img"
 
 _remove_quota() {
     /bin/echo -e "\033[1;32mRemoving quota...\033[0m"
-    umount -d "$VOL_DIR"
+    umount -d "$VOL_DIR" 2>/dev/null || true
     rm -f "$IMAGE_FILE"
-    sed -i "\|${IMAGE_FILE}|d" /etc/fstab
+
+    flock -w 10 -e 200 -c "
+        /bin/echo \"\$(sed \"/${PROJ_NAME}/d\" /etc/fstab)\" > /etc/fstab
+    "
 }
 
 _remove_dir() {

--- a/charts/vessl/charts/lpp-advanced-config/templates/config-map.yaml
+++ b/charts/vessl/charts/lpp-advanced-config/templates/config-map.yaml
@@ -32,9 +32,9 @@ data:
             mountPropagation: Bidirectional
           - name: fstab
             mountPath: /etc/fstab
-        env:
-        - name: VOL_DIR_PARENT
-          value: {{ .Values.path.default }}
+          env:
+          - name: VOL_DIR_PARENT
+            value: {{ .Values.path.default }}
       volumes:
       - name: fstab
         hostPath:


### PR DESCRIPTION
loop device mount가 간헐적으로 실패하는데, mount 명령어가 atomic하지 않아 동시성 이슈가 발생하는 것을 원인으로 짐작하고 있습니다.

동시성이 발생할 수 있는 작업 수행 시에 (`/etc/fstab`, `mount device`) 락을 겁니다.

그리고 helper pod에서 index 에러를 해결합니다.
또한 TRAP ERR은 bash에서만 지원이 가능한데, EXIT을 사용하더라도 동일한 동작을 하기에 EXIT으로 수정합니다.