### PR TITLE
add priorityclasses resources in clusterrole

### DIFF
--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.57
+version: 0.0.58
 appVersion: "0.6.30-rc2"
 dependencies:
 - name: node-feature-discovery

--- a/charts/vessl/templates/clusterrole.yaml
+++ b/charts/vessl/templates/clusterrole.yaml
@@ -11,6 +11,6 @@ rules:
     {{- if eq .Values.agent.scope "cluster" }}
     resources: ["*"]
     {{- else }}
-    resources: ["nodes", "persistentvolumes", "ingressclasses", "services"]
+    resources: ["nodes", "persistentvolumes", "ingressclasses", "services", "priorityclasses"]
     {{- end }}
     verbs: ["*"]


### PR DESCRIPTION
## Desc

vessl agent에서 priority classes를 추가할 수 있도록 수정

- role, rolebinding, service account는 정상적으로 각 namespace에 설정되어 있었음
- priority class는 cluster scope resource여서 cluster role에 해당 권한을 추가해주어야 함
- local 환경에서 가능했던 이유는 agent.scope이 기본적으로 'cluster'이기 때문에 모든 권한을 허용함
- dev에서는 agent.scope이 'namespace'로 설정되어 있음