### PR TITLE
Use DCGM and Device Plugin instead of GPU Operator

### DIFF
--- a/charts/vessl/Chart.lock
+++ b/charts/vessl/Chart.lock
@@ -8,6 +8,12 @@ dependencies:
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.44.0
+- name: dcgm-exporter
+  repository: https://nvidia.github.io/dcgm-exporter/helm-charts
+  version: 4.0.4
+- name: nvidia-device-plugin
+  repository: https://nvidia.github.io/k8s-device-plugin
+  version: 0.17.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 23.2.0
@@ -38,5 +44,5 @@ dependencies:
 - name: hostpath-csi-driver
   repository: ""
   version: 0.1.0
-digest: sha256:3cd3d21dceb2a15a124668e71f4c260f82888cfbc0ab67b0493975346e05dfe2
-generated: "2025-07-21T15:05:29.60866+09:00"
+digest: sha256:17b96f7551069fe2e777095c4e43da7f9293ef58603da130402e2bc6de5aefee
+generated: "2025-08-25T11:22:39.873881+09:00"

--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -4,53 +4,61 @@ type: application
 version: 0.0.61
 appVersion: "0.6.30-rc4"
 dependencies:
-- name: node-feature-discovery
-  version: "0.17.2"
-  alias: nfd
-  condition: nfd.enabled
-  repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
-- name: kube-state-metrics
-  version: "5.30.0"
-  condition: kube-state-metrics.enabled
-  repository: https://prometheus-community.github.io/helm-charts
-- name: prometheus-node-exporter
-  alias: node-exporter
-  version: "4.44.0"
-  condition: node-exporter.enabled
-  repository: https://prometheus-community.github.io/helm-charts
-- name: prometheus
-  alias: prometheus-remote-write
-  version: "23.2.0"
-  condition: prometheus-remote-write.enabled
-  repository: https://prometheus-community.github.io/helm-charts
-- name: longhorn
-  version: "1.5.1"
-  condition: longhorn.enabled
-  repository: https://charts.longhorn.io
-- name: local-path-provisioner
-  version: "0.0.24"
-  condition: local-path-provisioner.enabled
-- name: harbor
-  version: "1.0.1"
-  condition: harbor.enabled
-- name: prometheus-adapter
-  version: "4.9.0"
-  condition: prometheus-adapter.enabled
-  repository: https://prometheus-community.github.io/helm-charts
-- name: image-prepull
-  version: "0.1.0"
-  condition: image-prepull.enabled
-- name: lpp-advanced-config
-  version: "0.1.0"
-  condition: lpp-advanced-config.enabled
-- name: nginx-ingress
-  version: "2.0.1"
-  condition: nginx-ingress.enabled
-  repository: https://helm.nginx.com/stable
-- name: gpu-operator
-  version: "v24.9.2"
-  condition: gpu-operator.enabled
-  repository: https://nvidia.github.io/gpu-operator
-- name: hostpath-csi-driver
-  version: "0.1.0"
-  condition: hostpath-csi-driver.enabled
+  - name: node-feature-discovery
+    version: "0.17.2"
+    alias: nfd
+    condition: nfd.enabled
+    repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+  - name: kube-state-metrics
+    version: "5.30.0"
+    condition: kube-state-metrics.enabled
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: prometheus-node-exporter
+    alias: node-exporter
+    version: "4.44.0"
+    condition: node-exporter.enabled
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: dcgm-exporter
+    version: "4.0.4"
+    condition: dcgm-exporter.enabled
+    repository: https://nvidia.github.io/dcgm-exporter/helm-charts
+  - name: nvidia-device-plugin
+    version: "0.17.0"
+    condition: nvidia-device-plugin.enabled
+    repository: https://nvidia.github.io/k8s-device-plugin
+  - name: prometheus
+    alias: prometheus-remote-write
+    version: "23.2.0"
+    condition: prometheus-remote-write.enabled
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: longhorn
+    version: "1.5.1"
+    condition: longhorn.enabled
+    repository: https://charts.longhorn.io
+  - name: local-path-provisioner
+    version: "0.0.24"
+    condition: local-path-provisioner.enabled
+  - name: harbor
+    version: "1.0.1"
+    condition: harbor.enabled
+  - name: prometheus-adapter
+    version: "4.9.0"
+    condition: prometheus-adapter.enabled
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: image-prepull
+    version: "0.1.0"
+    condition: image-prepull.enabled
+  - name: lpp-advanced-config
+    version: "0.1.0"
+    condition: lpp-advanced-config.enabled
+  - name: nginx-ingress
+    version: "2.0.1"
+    condition: nginx-ingress.enabled
+    repository: https://helm.nginx.com/stable
+  - name: gpu-operator
+    version: "v24.9.2"
+    condition: gpu-operator.enabled
+    repository: https://nvidia.github.io/gpu-operator
+  - name: hostpath-csi-driver
+    version: "0.1.0"
+    condition: hostpath-csi-driver.enabled

--- a/charts/vessl/Chart.yaml
+++ b/charts/vessl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vessl
 type: application
-version: 0.0.61
+version: 0.0.62
 appVersion: "0.6.30-rc4"
 dependencies:
   - name: node-feature-discovery

--- a/charts/vessl/values.yaml
+++ b/charts/vessl/values.yaml
@@ -60,51 +60,9 @@ agent:
                 operator: "In"
                 values: ["manager"]
 
-# https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery
-nfd:
-  enabled: true
-  master:
-    tolerations:
-      - operator: "Exists"
-        effect: "NoSchedule"
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/master"
-                  operator: "In"
-                  values: [""]
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/control-plane"
-                  operator: "Exists"
-          - weight: 2
-            preference:
-              matchExpressions:
-                - key: "v1.k8s.vessl.ai/dedicated"
-                  operator: "In"
-                  values: ["manager"]
-    config:
-      extraLabelNs: ["nvidia.com"]
-  worker:
-    tolerations:
-      - operator: "Exists"
-        effect: "NoSchedule"
-    config:
-      sources:
-        pci:
-          deviceClassWhitelist:
-            - "02"
-            - "0200"
-            - "0207"
-            - "0300"
-            - "0302"
-          deviceLabelFields:
-            - "vendor"
-
+#############################
+# Monitoring ################
+#############################
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
 kube-state-metrics:
   enabled: true
@@ -164,6 +122,43 @@ node-exporter:
       prometheus.io/scrape: "true"
       v1.k8s.vessl.ai/managed: "true"
       v1.k8s.vessl.ai/type: node-exporter
+
+dcgm-exporter:
+  enabled: true
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+      v1.k8s.vessl.ai/managed: "true"
+      v1.k8s.vessl.ai/type: dcgm-exporter
+  serviceMonitor:
+    enabled: false
+  kubeletPath: "/var/lib/kubelet/pod-resources"
+  tolerations:
+    - operator: "Exists"
+      effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              # On discrete-GPU based systems NFD adds the following label where 10de is te NVIDIA PCI vendor ID
+              - key: "feature.node.kubernetes.io/pci-10de.present"
+                operator: "In"
+                values:
+                  - "true"
+          - matchExpressions:
+              # On some Tegra-based systems NFD detects the CPU vendor ID as NVIDIA
+              - key: "feature.node.kubernetes.io/cpu-model.vendor_id"
+                operator: "In"
+                values:
+                  - "NVIDIA"
+          - matchExpressions:
+              # We allow a GFD deployment to be forced by setting the following label to "true"
+              - key: "nvidia.com/gpu.present"
+                operator: In
+                values:
+                  - "true"
+
 
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
 prometheus-remote-write:
@@ -294,38 +289,6 @@ prometheus-remote-write:
       replacement: metrics
       action: replace
 
-# https://github.com/nginx/kubernetes-ingress/blob/main/charts/nginx-ingress
-nginx-ingress:
-  enabled: false
-  controller:
-    image:
-      tag: 4.0.1-alpine
-    ingressClass:
-      name: vessl-nginx
-    service:
-      create: false
-    enableSnippets: true
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/master"
-                  operator: "In"
-                  values: [""]
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: "node-role.kubernetes.io/control-plane"
-                  operator: "Exists"
-          - weight: 2
-            preference:
-              matchExpressions:
-                - key: "v1.k8s.vessl.ai/dedicated"
-                  operator: "In"
-                  values: ["manager"]
-
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-adapter
 prometheus-adapter:
   enabled: false
@@ -378,18 +341,93 @@ prometheus-adapter:
           as: "gpu_util"
         metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
 
-image-prepull:
-  enabled: false
+##########################
+# GPU ####################
+##########################
+# https://github.com/NVIDIA/k8s-device-plugin/tree/main/deployments/helm/nvidia-device-plugin
+nvidia-device-plugin:
+  enabled: true
+  deviceListStrategy: volume-mounts
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              # On discrete-GPU based systems NFD adds the following label where 10de is te NVIDIA PCI vendor ID
+              - key: "feature.node.kubernetes.io/pci-10de.present"
+                operator: "In"
+                values:
+                  - "true"
+          - matchExpressions:
+              # On some Tegra-based systems NFD detects the CPU vendor ID as NVIDIA
+              - key: "feature.node.kubernetes.io/cpu-model.vendor_id"
+                operator: "In"
+                values:
+                  - "NVIDIA"
+          - matchExpressions:
+              # We allow a GFD deployment to be forced by setting the following label to "true"
+              - key: "nvidia.com/gpu.present"
+                operator: In
+                values:
+                  - "true"
+  gfd:
+    enabled: true
+  nfd:
+    enabled: false
 
-# https://github.com/NVIDIA/gpu-operator/tree/master/charts/gpu-operator
+# https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery
+nfd:
+  enabled: true
+  master:
+    tolerations:
+      - operator: "Exists"
+        effect: "NoSchedule"
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: "node-role.kubernetes.io/master"
+                  operator: "In"
+                  values: [""]
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: "node-role.kubernetes.io/control-plane"
+                  operator: "Exists"
+          - weight: 2
+            preference:
+              matchExpressions:
+                - key: "v1.k8s.vessl.ai/dedicated"
+                  operator: "In"
+                  values: ["manager"]
+    config:
+      extraLabelNs: ["nvidia.com"]
+  worker:
+    tolerations:
+      - operator: "Exists"
+        effect: "NoSchedule"
+    config:
+      sources:
+        pci:
+          deviceClassWhitelist:
+            - "02"
+            - "0200"
+            - "0207"
+            - "0300"
+            - "0302"
+          deviceLabelFields:
+            - "vendor"
+
+
+# Currently, GPU Operator is only used for using MIG.
+# https://github.com/NVIDIA/gpu-operator/blob/main/deployments/gpu-operator/values.yaml
 gpu-operator:
   enabled: false
 
   operator:
     cleanupCRD: true
-
-  mig:
-    strategy: mixed # mixed / single / none
 
   driver:
     enabled: false
@@ -420,14 +458,18 @@ gpu-operator:
                   operator: In
                   values:
                     - "true"
-  
+
   gfd:
     enabled: true
   nfd:
     enabled: false
 
+  # if you want to use MIG, set this to "mixed" or "single" and set migManager.enabled to true
+  mig:
+    strategy: none # mixed / single / none
+
   migManager:
-    enabled: true
+    enabled: false
     env:
       - name: WITH_REBOOT
         value: "false"
@@ -465,7 +507,9 @@ gpu-operator:
   #               "4g.40gb": 1
 
 
+##########################
 ### Persistent Storage ###
+##########################
 # Recommended: Enable hostpath-csi-driver for hostPath-based volumes.
 hostpath-csi-driver:
   enabled: true
@@ -532,7 +576,7 @@ lpp-advanced-config:
     enabled: true
     size: 10g
 
-
+# Deprecated
 # https://github.com/longhorn/longhorn/tree/master/chart
 longhorn:
   enabled: false
@@ -548,3 +592,42 @@ longhorn:
 # https://github.com/vessl-ai/helm-charts/blob/main/charts/vessl/charts/harbor/values.yaml
 harbor:
   enabled: false
+
+
+##########################
+# Additional Components  #
+##########################  
+image-prepull:
+  enabled: false
+
+# https://github.com/nginx/kubernetes-ingress/blob/main/charts/nginx-ingress
+nginx-ingress:
+  enabled: false
+  controller:
+    image:
+      tag: 4.0.1-alpine
+    ingressClass:
+      name: vessl-nginx
+    service:
+      create: false
+    enableSnippets: true
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: "node-role.kubernetes.io/master"
+                  operator: "In"
+                  values: [""]
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: "node-role.kubernetes.io/control-plane"
+                  operator: "Exists"
+          - weight: 2
+            preference:
+              matchExpressions:
+                - key: "v1.k8s.vessl.ai/dedicated"
+                  operator: "In"
+                  values: ["manager"]


### PR DESCRIPTION
https://vessl-ai.slack.com/archives/C08K8LEQ19Q/p1755554375316029 지원을 하면서 보인 수정사항들을 반영합니다.

* GPU Operator는 MIG를 위한 서브 차트로 용도를 제한합니다. 따라서 이전에 사용했던 Device Plugin과 DCGM Exporter를 다시 추가했습니다.
* values.yaml에 산재되어 있던 값들을 가독성 향상을 위해 주석(monitoring, gpu, persistent storage, misc)으로 분류했습니다.